### PR TITLE
Replace concrete view controller types with protocols to make the coordinator more testable

### DIFF
--- a/MVVMC Example.xcodeproj/project.pbxproj
+++ b/MVVMC Example.xcodeproj/project.pbxproj
@@ -58,6 +58,8 @@
 		9ACBC10B26BAC1CE00B5B0D2 /* HFTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ACBC10A26BAC1CE00B5B0D2 /* HFTabBarController.swift */; };
 		C3300B8E26F0BD6A0043B377 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = C3300B8D26F0BD6A0043B377 /* Kingfisher */; };
 		C34052ED26CBE71900824B57 /* DateViewCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34052EC26CBE71900824B57 /* DateViewCoordinator.swift */; };
+		C34D8916273AB09B00833867 /* ViewNavigationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34D8915273AB09B00833867 /* ViewNavigationProvider.swift */; };
+		C34D8918273AB0E000833867 /* ViewPresentationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34D8917273AB0E000833867 /* ViewPresentationProvider.swift */; };
 		C38C658226B96976008A3975 /* RecipeListCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C38C658126B96976008A3975 /* RecipeListCoordinator.swift */; };
 		EF30F4EE26C844B0008D6980 /* ActionsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF30F4ED26C844B0008D6980 /* ActionsCoordinator.swift */; };
 		EF30F4F026C844E3008D6980 /* ActionsViewBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF30F4EF26C844E3008D6980 /* ActionsViewBuilder.swift */; };
@@ -142,6 +144,8 @@
 		9ACBC10826B97AE800B5B0D2 /* RecipeDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeDetailsViewModel.swift; sourceTree = "<group>"; };
 		9ACBC10A26BAC1CE00B5B0D2 /* HFTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HFTabBarController.swift; sourceTree = "<group>"; };
 		C34052EC26CBE71900824B57 /* DateViewCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateViewCoordinator.swift; sourceTree = "<group>"; };
+		C34D8915273AB09B00833867 /* ViewNavigationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewNavigationProvider.swift; sourceTree = "<group>"; };
+		C34D8917273AB0E000833867 /* ViewPresentationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewPresentationProvider.swift; sourceTree = "<group>"; };
 		C38C658126B96976008A3975 /* RecipeListCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeListCoordinator.swift; sourceTree = "<group>"; };
 		EF30F4ED26C844B0008D6980 /* ActionsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionsCoordinator.swift; sourceTree = "<group>"; };
 		EF30F4EF26C844E3008D6980 /* ActionsViewBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionsViewBuilder.swift; sourceTree = "<group>"; };
@@ -205,6 +209,8 @@
 			children = (
 				9A68FD6C26A70D7A002F131D /* Coordinator.swift */,
 				9A68FD6E26A70E52002F131D /* BaseCoordinator.swift */,
+				C34D8915273AB09B00833867 /* ViewNavigationProvider.swift */,
+				C34D8917273AB0E000833867 /* ViewPresentationProvider.swift */,
 			);
 			path = Coordinator;
 			sourceTree = "<group>";
@@ -745,6 +751,7 @@
 				7F98518126F0D26500724973 /* DateAndTimeContainerViewController.swift in Sources */,
 				9AAE21E126A5CE49000483E2 /* Networking.swift in Sources */,
 				9AAE220E26A5D18F000483E2 /* LoadingView.swift in Sources */,
+				C34D8916273AB09B00833867 /* ViewNavigationProvider.swift in Sources */,
 				9AAE21F826A5CF8F000483E2 /* RecipeRepositoryProtocol.swift in Sources */,
 				9AAE21F926A5CF8F000483E2 /* Recipe.swift in Sources */,
 				EF30F4F026C844E3008D6980 /* ActionsViewBuilder.swift in Sources */,
@@ -773,6 +780,7 @@
 				9AAE222C26A5D350000483E2 /* DateCellViewModel.swift in Sources */,
 				9AAE220B26A5D18F000483E2 /* UITableView+Extensions.swift in Sources */,
 				9AAE222426A5D350000483E2 /* RecipeListViewModel.swift in Sources */,
+				C34D8918273AB0E000833867 /* ViewPresentationProvider.swift in Sources */,
 				C34052ED26CBE71900824B57 /* DateViewCoordinator.swift in Sources */,
 				9AAE222A26A5D350000483E2 /* RecipeCellViewModel.swift in Sources */,
 				9AAE220926A5D18F000483E2 /* UIFont+Extensions.swift in Sources */,

--- a/MVVMC Example/App/UI/Actions/Coordinator/ActionsCoordinator.swift
+++ b/MVVMC Example/App/UI/Actions/Coordinator/ActionsCoordinator.swift
@@ -14,10 +14,10 @@ protocol ActionsViewControllerActions: AnyObject {
 final class ActionsCoordinator: BaseCoordinator {
     struct Dependency {
         private let builder: ActionsViewBuilder
-        let sourceController: UIViewController
+        let sourceController: ViewPresentationProvider
         
         init(builder: ActionsViewBuilder,
-             sourceController: UIViewController) {
+             sourceController: ViewPresentationProvider) {
             self.builder = builder
             self.sourceController = sourceController
         }
@@ -39,7 +39,7 @@ final class ActionsCoordinator: BaseCoordinator {
     }
 
     override func start() {
-        
+
         let actionSheetController = DynamicActionSheetController.create(
             from: dependency.sourceController,
             rootViewController: viewController,

--- a/MVVMC Example/App/UI/Coordinator/ViewNavigationProvider.swift
+++ b/MVVMC Example/App/UI/Coordinator/ViewNavigationProvider.swift
@@ -1,0 +1,21 @@
+//
+//  ViewNavigationProvider.swift
+//  MVVMC Example
+//
+//  Created by Abbas Ali Awan on 09.11.21.
+//
+
+import UIKit
+
+protocol ViewNavigationProvider {
+    func pushViewController(_ viewController: UIViewController, animated: Bool)
+    func popViewController(animated: Bool) -> UIViewController?
+    func popToRootViewController(animated: Bool) -> [UIViewController]?
+    func setViewControllers(_ viewControllers: [UIViewController], animated: Bool)
+    var topViewController: UIViewController? { get }
+    var visibleViewController: UIViewController? { get }
+    var viewControllers: [UIViewController] { get set }
+    var delegate: UINavigationControllerDelegate? { get set }
+}
+
+extension UINavigationController: ViewNavigationProvider {}

--- a/MVVMC Example/App/UI/Coordinator/ViewPresentationProvider.swift
+++ b/MVVMC Example/App/UI/Coordinator/ViewPresentationProvider.swift
@@ -1,0 +1,15 @@
+//
+//  ViewPresentationProvider.swift
+//  MVVMC Example
+//
+//  Created by Abbas Ali Awan on 09.11.21.
+//
+
+import UIKit
+
+protocol ViewPresentationProvider {
+    func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)?)
+    func dismiss(animated flag: Bool, completion: (() -> Void)?)
+}
+
+extension UIViewController: ViewPresentationProvider {}

--- a/MVVMC Example/App/UI/DateAndTime/Date/DateViewCoordinator.swift
+++ b/MVVMC Example/App/UI/DateAndTime/Date/DateViewCoordinator.swift
@@ -15,7 +15,7 @@ final class DateViewCoordinator: BaseCoordinator {
     
     private let flow: Flow
 
-    let sourceController: UIViewController
+    let sourceController: ViewPresentationProvider
     
     init(flow: Flow, sourceController: UIViewController) {
         self.flow = flow

--- a/MVVMC Example/App/UI/DynamicActionSheetController.swift
+++ b/MVVMC Example/App/UI/DynamicActionSheetController.swift
@@ -92,7 +92,7 @@ final class DynamicActionSheetController: UIViewController {
     private let style: Style
     weak var dismissalDelegate: DynamicActionSheetControllerDismissalDelegate?
 
-    static func create(from presenterViewController: UIViewController,
+    static func create(from presenterViewController: ViewPresentationProvider,
                        rootViewController: DynamicActionSheetViewController,
                        style: Style = .default) -> DynamicActionSheetController {
         let viewController = DynamicActionSheetController(style: style)
@@ -101,7 +101,7 @@ final class DynamicActionSheetController: UIViewController {
         viewController.transitioningDelegate = viewController
         viewController.modalPresentationStyle = .custom
 
-        presenterViewController.present(viewController, animated: true)
+        presenterViewController.present(viewController, animated: true, completion: nil)
 
         return viewController
     }

--- a/MVVMC Example/App/UI/Recipe/RecipeDetails/Coordinator/RecipeDetailsCoordinator.swift
+++ b/MVVMC Example/App/UI/Recipe/RecipeDetails/Coordinator/RecipeDetailsCoordinator.swift
@@ -15,10 +15,10 @@ protocol RecipeDetailsViewActions: AnyObject {
 final class RecipeDetailsCoordinator: BaseCoordinator {
     struct Dependency {
         private let builder: RecipeDetailsViewBuilder
-        let sourceController: UINavigationController
+        let sourceController: ViewNavigationProvider
         
         init(builder: RecipeDetailsViewBuilder,
-             sourceController: UINavigationController) {
+             sourceController: ViewNavigationProvider) {
             self.builder = builder
             self.sourceController = sourceController
         }
@@ -47,7 +47,7 @@ final class RecipeDetailsCoordinator: BaseCoordinator {
 
 extension RecipeDetailsCoordinator: RecipeDetailsViewActions {
     func didTapBackButton() {
-        dependency
+        _ = dependency
             .sourceController
             .popViewController(animated: true)
         

--- a/MVVMC Example/App/UI/Recipe/RecipeDetails/View/RecipeDetailsViewController.swift
+++ b/MVVMC Example/App/UI/Recipe/RecipeDetails/View/RecipeDetailsViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Combine
 
 final class RecipeDetailsViewController: UIViewController {
     private lazy var imageView: UIImageView = {
@@ -42,6 +43,7 @@ final class RecipeDetailsViewController: UIViewController {
     }()
 
     private let viewModel: RecipeDetailsViewModel
+    private var disposables: Set<AnyCancellable> = []
 
     init(viewModel: RecipeDetailsViewModel) {
         self.viewModel = viewModel
@@ -58,6 +60,7 @@ final class RecipeDetailsViewController: UIViewController {
         setupUI()
         bindViewModel()
         setActions()
+        viewModel.viewDidLoad()
     }
 
     private func setupUI() {
@@ -85,9 +88,17 @@ final class RecipeDetailsViewController: UIViewController {
     }
 
     private func bindViewModel() {
-        recipeTitle.text = viewModel.title
-        recipeHeadline.text = viewModel.headline
-        imageView.kf.setImage(with: viewModel.image)
+        viewModel.title.sink { [weak self] title in
+            self?.recipeTitle.text = title
+        }.store(in: &disposables)
+
+        viewModel.headline.sink { [weak self] recipeHeadline in
+            self?.recipeHeadline.text = recipeHeadline
+        }.store(in: &disposables)
+
+        viewModel.image.sink { [weak self] image in
+            self?.imageView.kf.setImage(with: image)
+        }.store(in: &disposables)
     }
 
     private func setActions() {

--- a/MVVMC Example/App/UI/Recipe/RecipeDetails/ViewModel/RecipeDetailsViewModel.swift
+++ b/MVVMC Example/App/UI/Recipe/RecipeDetails/ViewModel/RecipeDetailsViewModel.swift
@@ -6,14 +6,16 @@
 //
 
 import Foundation
+import Combine
 
 protocol RecipeDetailsViewModelOutput {
-    var title: String { get }
-    var image: URL? { get }
-    var headline: String { get }
+    var title: PassthroughSubject<String, Never> { get }
+    var image: PassthroughSubject<URL?, Never> { get }
+    var headline: PassthroughSubject<String, Never> { get }
 }
 
 protocol RecipeDetailsViewModelInput {
+    func viewDidLoad()
     func didTapBackButton()
     func didTapActionsButton()
 }
@@ -23,9 +25,9 @@ protocol RecipeDetailsViewModelProtocol: RecipeDetailsViewModelInput, RecipeDeta
 }
 
 final class RecipeDetailsViewModel: RecipeDetailsViewModelProtocol {
-    var title: String { recipe.title }
-    var image: URL? { URL(string: recipe.image) }
-    var headline: String { recipe.headline }
+    var title: PassthroughSubject<String, Never> = PassthroughSubject()
+    var image: PassthroughSubject<URL?, Never> = PassthroughSubject()
+    var headline: PassthroughSubject<String, Never> = PassthroughSubject()
     
     private let recipe: Recipe
     private weak var actions: RecipeDetailsViewActions?
@@ -41,6 +43,11 @@ final class RecipeDetailsViewModel: RecipeDetailsViewModelProtocol {
 
     func didTapActionsButton() {
         actions?.didTapActionsButton(recipe: recipe)
-        
+    }
+
+    func viewDidLoad() {
+        title.send(recipe.title)
+        headline.send(recipe.headline)
+        image.send(URL(string: recipe.image))
     }
 }

--- a/MVVMC Example/App/UI/Recipe/RecipeList/Coordinator/RecipeListCoordinator.swift
+++ b/MVVMC Example/App/UI/Recipe/RecipeList/Coordinator/RecipeListCoordinator.swift
@@ -15,7 +15,7 @@ protocol RecipeListActions: AnyObject {
 final class RecipeListCoordinator: BaseCoordinator {
     struct Dependency {
         private let builder: RecipeListViewBuilder
-        let sourceController: UINavigationController
+        let sourceController: ViewNavigationProvider
         
         init(builder: RecipeListViewBuilder, sourceController: UINavigationController) {
             self.builder = builder

--- a/MVVMC Example/App/UI/Recipe/RecipeList/View/ViewController/RecipeListViewController.swift
+++ b/MVVMC Example/App/UI/Recipe/RecipeList/View/ViewController/RecipeListViewController.swift
@@ -11,6 +11,7 @@ import Combine
 class RecipeListViewController: UITableViewController, AlertsPresentable {
 
     private let viewModel: RecipeListViewModel
+    private var disposables: Set<AnyCancellable> = []
 
     init(viewModel: RecipeListViewModel) {
         self.viewModel = viewModel
@@ -38,7 +39,7 @@ class RecipeListViewController: UITableViewController, AlertsPresentable {
     }
 
     private func bindViewModel() {
-        viewModel.viewStateUpdated = { [weak self] state in
+        viewModel.viewState.sink { [weak self] state in
             guard let self = self else { return }
             switch state {
             case .initial:
@@ -51,7 +52,7 @@ class RecipeListViewController: UITableViewController, AlertsPresentable {
             case .failed(let message):
                 self.showAlert(with: "Error", and: message)
             }
-        }
+        }.store(in: &disposables)
     }
  }
 


### PR DESCRIPTION
Here we replace concrete view controller types with protocols to make the coordinator more testable.